### PR TITLE
Update example server code to properly show adding a custom endpoint 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ FastAPI + WebSockets + PubSub ==  ⚡💪 ❤️
         ```python
         app = FastAPI() 
         endpoint = PubSubEndpoint()
-        endpoint.register_route(app, "/pubsub")
+        endpoint.register_route(app, path="/pubsub")
         endpoint.publish(["my_event_topic"], data=["my", "data", 1])
         ```
     - From client to client (through the servers)

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -42,7 +42,7 @@ def setup_server():
     app = FastAPI()
     # PubSub websocket endpoint
     endpoint = PubSubEndpoint()
-    endpoint.register_route(app, "/pubsub")
+    endpoint.register_route(app, path="/pubsub")
     # Regular REST endpoint - that publishes to PubSub
     setup_server_rest_route(app, endpoint)
     uvicorn.run(app, port=PORT)

--- a/tests/multiprocess_test.py
+++ b/tests/multiprocess_test.py
@@ -38,7 +38,7 @@ def setup_server():
     router = APIRouter()
     # PubSub websocket endpoint
     endpoint = PubSubEndpoint()
-    endpoint.register_route(router, "/pubsub")
+    endpoint.register_route(router, path="/pubsub")
     app.include_router(router)
     uvicorn.run(app, port=PORT)
 

--- a/tests/reconnect_test.py
+++ b/tests/reconnect_test.py
@@ -55,7 +55,7 @@ def setup_server(disconnect_delay=0):
 
     # PubSub websocket endpoint
     endpoint = PubSubEndpoint(on_connect=[on_connect])
-    endpoint.register_route(app, "/pubsub")
+    endpoint.register_route(app, path="/pubsub")
     uvicorn.run(app, port=PORT)
 
 

--- a/tests/server_subscriber_test.py
+++ b/tests/server_subscriber_test.py
@@ -41,7 +41,7 @@ def setup_server():
     app = FastAPI()
     # PubSub websocket endpoint
     endpoint = PubSubEndpoint()
-    endpoint.register_route(app, "/pubsub")
+    endpoint.register_route(app, path="/pubsub")
 
     # receive an event and publish another (this time for the client)
     async def event_callback(subscription: Subscription, data):

--- a/tests/server_with_remote_id_test.py
+++ b/tests/server_with_remote_id_test.py
@@ -72,7 +72,7 @@ def setup_server():
 
     # PubSub websocket endpoint - setting up the server with remote id
     endpoint = PubSubEndpoint(rpc_channel_get_remote_id=True, on_connect=[on_connect])
-    endpoint.register_route(app, "/pubsub")
+    endpoint.register_route(app, path="/pubsub")
 
     # Regular REST endpoint - that publishes to PubSub
     setup_server_rest_routes(app, endpoint, remote_id_ok)


### PR DESCRIPTION
Per discussion here - https://github.com/permitio/fastapi_websocket_pubsub/discussions/31#discussioncomment-2252740

The endpoint_register function requires path to be specified when adding a custom route.