### PR TITLE
change boundaries of dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f ./tests/requirements.txt ]; then pip install -r ./tests/requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+# Handling DeprecationWarning 'asyncio_mode' default value
+[pytest]
+asyncio_mode = strict

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-asyncio
+requests
+twine
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi-websocket-rpc>=0.1.21,<1
 broadcaster>=0.2.0,<1
+pydantic>=1.9.1,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fastapi-websocket-rpc>=0.1.21
-broadcaster==0.2.0
+fastapi-websocket-rpc>=0.1.21,<1
+broadcaster>=0.2.0,<1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi-websocket-rpc>=0.1.21,<1
 broadcaster>=0.2.0,<1
 pydantic>=1.9.1,<2
+websockets>=10.3,<11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi-websocket-rpc>=0.1.21,<1
+fastapi-websocket-rpc>=0.1.22,<1
 broadcaster>=0.2.0,<1
 pydantic>=1.9.1,<2
 websockets>=10.3,<11


### PR DESCRIPTION
Now, every dependency has a minimum required version of the latest stable version, and is not allowed to upgrade to the next major version.