### PR TITLE
Rk/fix python311

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,4 +38,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        pytest --timeout 180

--- a/fastapi_websocket_pubsub/pub_sub_server.py
+++ b/fastapi_websocket_pubsub/pub_sub_server.py
@@ -133,8 +133,11 @@ class PubSubEndpoint:
                 logger.debug("Entering endpoint's main loop with broadcaster")
                 if self._ignore_broadcaster_disconnected:
                     await self.endpoint.main_loop(websocket, client_id=client_id, **kwargs)
-                else:        
-                    done, pending = await asyncio.wait([self.endpoint.main_loop(websocket, client_id=client_id, **kwargs),
+                else:
+                    main_loop_task = asyncio.create_task(
+                        self.endpoint.main_loop(websocket, client_id=client_id, **kwargs)
+                    )
+                    done, pending = await asyncio.wait([main_loop_task,
                                                         self.broadcaster.get_reader_task()],
                                                         return_when=asyncio.FIRST_COMPLETED)
                     logger.debug(f"task is done: {done}")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ twine
 wheel
 loguru
 uvicorn
+pytest-timeout

--- a/tests/broadcaster_test.py
+++ b/tests/broadcaster_test.py
@@ -110,10 +110,6 @@ def server(postgres):
     proc.kill()  # Cleanup after test
 
 
-
-skip_unless_requested = pytest.mark.skipif(os.environ.get('TEST_BROADCAST') is None, reason="Not configured to test for broadcast (requires Postgres) | enable with TEST_BROADCAST=1")
-
-@skip_unless_requested
 @pytest.mark.asyncio
 async def test_all_clients_get_a_topic_via_broadcast(server, repeats=1, interval=0):
     """
@@ -159,8 +155,6 @@ async def test_all_clients_get_a_topic_via_broadcast(server, repeats=1, interval
                 if repeat + 1 < repeats:
                     await asyncio.sleep(interval)
 
-
-@skip_unless_requested
 @pytest.mark.postgres_idle_timeout(3000)
 @pytest.mark.asyncio
 async def test_idle_pg_broadcaster_disconnect(server):


### PR DESCRIPTION
1. Broadcast test wasn't parallel safe - executed container with a constant name (chances for the bug to occur in CI tests were drastically increased with the addition of Python 3.11 & 3.10 to the tests matrix).
2. Bugfix in `PubSubEndpoint` calling `asyncio.wait` with an unwrapped coroutine (not supported in Python 3.11 - made broadcast test hang) 
3. Reverted skipping the broadcast tests - after solving those issues they now pass. (and we definitely want those to run)
4. Have pytest run with timeout (Much easier to deal with hanging tests) 