### PR TITLE
Rk/fix context manager lock

### DIFF
--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -8,7 +8,7 @@ from .logger import get_logger
 from fastapi_websocket_rpc.utils import gen_uid
 
 
-logger = get_logger('EventBroadcaster')
+logger = get_logger("EventBroadcaster")
 
 
 # Cross service broadcast consts
@@ -35,9 +35,14 @@ class EventBroadcasterContextManager:
     Friend-like class of EventBroadcaster (accessing "protected" members )
     """
 
-    def __init__(self, event_broadcaster: "EventBroadcaster", listen: bool = True, share: bool = True) -> None:
+    def __init__(
+        self,
+        event_broadcaster: "EventBroadcaster",
+        listen: bool = True,
+        share: bool = True,
+    ) -> None:
         """
-        Provide a context manager for an EventBroadcaster, managing if it listens to events coming from the broadcaster 
+        Provide a context manager for an EventBroadcaster, managing if it listens to events coming from the broadcaster
         and if it subscribes to the internal notifier to share its events with the broadcaster
 
         Args:
@@ -48,15 +53,16 @@ class EventBroadcasterContextManager:
         self._event_broadcaster = event_broadcaster
         self._share: bool = share
         self._listen: bool = listen
-        self._lock = asyncio.Lock()
 
     async def __aenter__(self):
-        async with self._lock:
+        async with self._event_broadcaster._manage_lock:
             if self._listen:
                 self._event_broadcaster._listen_count += 1
                 if self._event_broadcaster._listen_count == 1:
                     # We have our first listener start the read-task for it (And all those who'd follow)
-                    logger.info("Listening for incoming events from broadcast channel (first listener started)")
+                    logger.info(
+                        "Listening for incoming events from broadcast channel (first listener started)"
+                    )
                     # Start task listening on incoming broadcasts
                     self._event_broadcaster.start_reader_task()
 
@@ -66,15 +72,19 @@ class EventBroadcasterContextManager:
                     # We have our first publisher
                     # Init the broadcast used for sharing (reading has its own)
                     self._event_broadcaster._acquire_sharing_broadcast_channel()
-                    logger.debug("Subscribing to ALL_TOPICS, and sharing messages with broadcast channel")
+                    logger.debug(
+                        "Subscribing to ALL_TOPICS, and sharing messages with broadcast channel"
+                    )
                     # Subscribe to internal events form our own event notifier and broadcast them
                     await self._event_broadcaster._subscribe_to_all_topics()
                 else:
-                    logger.debug(f"Did not subscribe to ALL_TOPICS: share count == {self._event_broadcaster._share_count}")
+                    logger.debug(
+                        f"Did not subscribe to ALL_TOPICS: share count == {self._event_broadcaster._share_count}"
+                    )
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
-        async with self._lock:
+        async with self._event_broadcaster._manage_lock:
             try:
                 if self._listen:
                     self._event_broadcaster._listen_count -= 1
@@ -87,7 +97,7 @@ class EventBroadcasterContextManager:
                             self._event_broadcaster._subscription_task = None
 
                 if self._share:
-                    self._event_broadcaster._share_count -= 1     
+                    self._event_broadcaster._share_count -= 1
                     # if this was last sharer - we can stop subscribing to internal events - we aren't sharing anymore
                     if self._event_broadcaster._share_count == 0:
                         # Unsubscribe from internal events
@@ -110,8 +120,14 @@ class EventBroadcaster:
         <Your Code>
     """
 
-    def __init__(self, broadcast_url: str, notifier: EventNotifier, channel="EventNotifier",
-                 broadcast_type=None, is_publish_only=False) -> None:
+    def __init__(
+        self,
+        broadcast_url: str,
+        notifier: EventNotifier,
+        channel="EventNotifier",
+        broadcast_type=None,
+        is_publish_only=False,
+    ) -> None:
         """
 
         Args:
@@ -138,10 +154,11 @@ class EventBroadcaster:
         self._publish_lock = None
         # used to track creation / removal of resources needed per type (reader task->listen, and subscription to internal events->share)
         self._listen_count: int = 0
-        self._share_count: int = 0     
-        # If we opt to manage the context directly (i.e. call async with on the event broadcaster itself)   
+        self._share_count: int = 0
+        # If we opt to manage the context directly (i.e. call async with on the event broadcaster itself)
         self._context_manager = None
-
+        # To be used by the context manager for securing share/listen ref counts
+        self._manage_lock = asyncio.Lock()
 
     async def __broadcast_notifications__(self, subscription: Subscription, data):
         """
@@ -151,13 +168,20 @@ class EventBroadcaster:
             subscription (Subscription): the subscription that got triggered
             data: the event data
         """
-        logger.info("Broadcasting incoming event: {}".format({'topic': subscription.topic, 'notifier_id': self._id}))
-        note = BroadcastNotification(notifier_id=self._id, topics=[
-                                     subscription.topic], data=data)
+        logger.info(
+            "Broadcasting incoming event: {}".format(
+                {"topic": subscription.topic, "notifier_id": self._id}
+            )
+        )
+        note = BroadcastNotification(
+            notifier_id=self._id, topics=[subscription.topic], data=data
+        )
         # Publish event to broadcast
         async with self._publish_lock:
             async with self._sharing_broadcast_channel:
-                await self._sharing_broadcast_channel.publish(self._channel, note.json())
+                await self._sharing_broadcast_channel.publish(
+                    self._channel, note.json()
+                )
 
     def _acquire_sharing_broadcast_channel(self):
         """
@@ -167,9 +191,9 @@ class EventBroadcaster:
         self._sharing_broadcast_channel = self._broadcast_type(self._broadcast_url)
 
     async def _subscribe_to_all_topics(self):
-        return await self._notifier.subscribe(self._id,
-                                              ALL_TOPICS,
-                                              self.__broadcast_notifications__)
+        return await self._notifier.subscribe(
+            self._id, ALL_TOPICS, self.__broadcast_notifications__
+        )
 
     async def _unsubscribe_from_topics(self):
         return await self._notifier.unsubscribe(self._id)
@@ -183,16 +207,16 @@ class EventBroadcaster:
             share (bool, optional): Should we share events with the broadcast channel. Defaults to True.
 
         Returns:
-            EventBroadcasterContextManager: the context 
+            EventBroadcasterContextManager: the context
         """
         return EventBroadcasterContextManager(self, listen=listen, share=share)
 
     def get_listening_context(self):
         return EventBroadcasterContextManager(self, listen=True, share=False)
-                                  
+
     def get_sharing_context(self):
         return EventBroadcasterContextManager(self, listen=False, share=True)
-                                    
+
     async def __aenter__(self):
         """
         Convince caller (also backward compaltability)
@@ -200,7 +224,6 @@ class EventBroadcaster:
         if self._context_manager is None:
             self._context_manager = self.get_context(listen=not self._is_publish_only)
         return await self._context_manager.__aenter__()
-
 
     async def __aexit__(self, exc_type, exc, tb):
         await self._context_manager.__aexit__(exc_type, exc, tb)
@@ -215,14 +238,15 @@ class EventBroadcaster:
         # Make sure a task wasn't started already
         if self._subscription_task is not None:
             # we already started a task for this worker process
-            logger.debug("No need for listen task, already started broadcast listen task for this notifier")
+            logger.debug(
+                "No need for listen task, already started broadcast listen task for this notifier"
+            )
             return
         # Trigger the task
         logger.debug("Spawning broadcast listen task")
-        self._subscription_task = asyncio.create_task(
-            self.__read_notifications__())
+        self._subscription_task = asyncio.create_task(self.__read_notifications__())
         return self._subscription_task
-    
+
     def get_reader_task(self):
         return self._subscription_task
 
@@ -235,15 +259,27 @@ class EventBroadcaster:
         listening_broadcast_channel = self._broadcast_type(self._broadcast_url)
         async with listening_broadcast_channel:
             # Subscribe to our channel
-            async with listening_broadcast_channel.subscribe(channel=self._channel) as subscriber:
+            async with listening_broadcast_channel.subscribe(
+                channel=self._channel
+            ) as subscriber:
                 async for event in subscriber:
                     try:
-                        notification = BroadcastNotification.parse_raw(
-                            event.message)
+                        notification = BroadcastNotification.parse_raw(event.message)
                         # Avoid re-publishing our own broadcasts
                         if notification.notifier_id != self._id:
-                            logger.info("Handling incoming broadcast event: {}".format({'topics': notification.topics, 'src': notification.notifier_id}))
+                            logger.info(
+                                "Handling incoming broadcast event: {}".format(
+                                    {
+                                        "topics": notification.topics,
+                                        "src": notification.notifier_id,
+                                    }
+                                )
+                            )
                             # Notify subscribers of message received from broadcast
-                            await self._notifier.notify(notification.topics, notification.data, notifier_id=self._id)
+                            await self._notifier.notify(
+                                notification.topics,
+                                notification.data,
+                                notifier_id=self._id,
+                            )
                     except:
                         logger.exception("Failed handling incoming broadcast")

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,20 @@
 from setuptools import setup, find_packages
 
+
 def get_requirements(env=""):
     if env:
         env = "-{}".format(env)
     with open("requirements{}.txt".format(env)) as fp:
         return [x.strip() for x in fp.read().split("\n") if not x.startswith("#")]
 
+
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name='fastapi_websocket_pubsub',
-    version='0.3.3',
-    author='Or Weis',
+    name="fastapi_websocket_pubsub",
+    version="0.3.4",
+    author="Or Weis",
     author_email="or@permit.io",
     description="A fast and durable PubSub channel over Websockets (using fastapi-websockets-rpc).",
     long_description_content_type="text/markdown",
@@ -24,8 +26,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
-        "Topic :: Internet :: WWW/HTTP :: WSGI"
+        "Topic :: Internet :: WWW/HTTP :: WSGI",
     ],
-    python_requires='>=3.7',
+    python_requires=">=3.7",
     install_requires=get_requirements(),
 )


### PR DESCRIPTION
different instances of `EventBroadcasterContextManager` were using different locks when securing access to the same `EventBroadcaster` instance's resources. 
Use the same lock by using a member of the `EventBroadcaster`.

Also fixed file formatting.