### PR TITLE
Version 0.3.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi-websocket-rpc>=0.1.24,<1
-permit-broadcaster[redis,postgres,kafka]==0.2.2
+permit-broadcaster[redis,postgres,kafka]==0.2.3
 pydantic>=1.9.1,<2
 websockets>=10.3,<11

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="fastapi_websocket_pubsub",
-    version="0.3.3",
+    version="0.3.4",
     author="Or Weis",
     author_email="or@permit.io",
     description="A fast and durable PubSub channel over Websockets (using fastapi-websockets-rpc).",

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,20 @@
 from setuptools import setup, find_packages
 
+
 def get_requirements(env=""):
     if env:
         env = "-{}".format(env)
     with open("requirements{}.txt".format(env)) as fp:
         return [x.strip() for x in fp.read().split("\n") if not x.startswith("#")]
 
+
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name='fastapi_websocket_pubsub',
-    version='0.3.3',
-    author='Or Weis',
+    name="fastapi_websocket_pubsub",
+    version="0.3.3",
+    author="Or Weis",
     author_email="or@permit.io",
     description="A fast and durable PubSub channel over Websockets (using fastapi-websockets-rpc).",
     long_description_content_type="text/markdown",
@@ -24,8 +26,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
-        "Topic :: Internet :: WWW/HTTP :: WSGI"
+        "Topic :: Internet :: WWW/HTTP :: WSGI",
     ],
-    python_requires='>=3.7',
+    python_requires=">=3.8",
     install_requires=get_requirements(),
 )


### PR DESCRIPTION
1. Upgrade broadcaster to newest version (including support for Kafka SSL params)
2. Drop python 3.7 support
3. Bump version to 0.3.4