### PR TITLE
Support both Pydantic v1 and v2

### DIFF
--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -7,7 +7,7 @@ from pydantic.main import BaseModel
 
 from .event_notifier import ALL_TOPICS, EventNotifier, Subscription, TopicList
 from .logger import get_logger
-from .util import get_model_serializer
+from .util import pydantic_serialize
 
 logger = get_logger("EventBroadcaster")
 
@@ -181,9 +181,8 @@ class EventBroadcaster:
         async with self._broadcast_type(
             self._broadcast_url
         ) as sharing_broadcast_channel:
-            model_serializer = get_model_serializer()
             await sharing_broadcast_channel.publish(
-                self._channel, model_serializer(note)
+                self._channel, pydantic_serialize(note)
             )
 
     async def _subscribe_to_all_topics(self):

--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -181,7 +181,9 @@ class EventBroadcaster:
             self._broadcast_url
         ) as sharing_broadcast_channel:
             model_serializer = get_model_serializer()
-            await sharing_broadcast_channel.publish(self._channel, model_serializer(note))
+            await sharing_broadcast_channel.publish(
+                self._channel, model_serializer(note)
+            )
 
     async def _subscribe_to_all_topics(self):
         return await self._notifier.subscribe(
@@ -278,8 +280,10 @@ class EventBroadcaster:
                             )
 
                             self._tasks.add(task)
+
                             def cleanup(task):
                                 self._tasks.remove(task)
+
                             task.add_done_callback(cleanup)
                     except:
                         logger.exception("Failed handling incoming broadcast")

--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -18,7 +18,7 @@ NotifierId = str
 class BroadcastNotification(BaseModel):
     notifier_id: NotifierId
     topics: TopicList
-    data: Any
+    data: Any = None
 
 
 class EventBroadcasterException(Exception):

--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -1,12 +1,13 @@
 import asyncio
-from typing import Any, Union
-from pydantic.main import BaseModel
-from .event_notifier import EventNotifier, Subscription, TopicList, ALL_TOPICS
+from typing import Any
+
 from broadcaster import Broadcast
-
-from .logger import get_logger
 from fastapi_websocket_rpc.utils import gen_uid
+from pydantic.main import BaseModel
 
+from .event_notifier import ALL_TOPICS, EventNotifier, Subscription, TopicList
+from .logger import get_logger
+from .util import get_model_serializer
 
 logger = get_logger("EventBroadcaster")
 

--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -180,7 +180,8 @@ class EventBroadcaster:
         async with self._broadcast_type(
             self._broadcast_url
         ) as sharing_broadcast_channel:
-            await sharing_broadcast_channel.publish(self._channel, note.json())
+            model_serializer = get_model_serializer()
+            await sharing_broadcast_channel.publish(self._channel, model_serializer(note))
 
     async def _subscribe_to_all_topics(self):
         return await self._notifier.subscribe(

--- a/fastapi_websocket_pubsub/event_notifier.py
+++ b/fastapi_websocket_pubsub/event_notifier.py
@@ -7,7 +7,7 @@ from fastapi_websocket_rpc.utils import gen_uid
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
 from .logger import get_logger
-from .util import get_model_dict
+from .util import pydantic_to_dict
 
 logger = get_logger("EventNotifier")
 
@@ -130,8 +130,7 @@ class EventNotifier:
                 )
                 subscriptions.append(new_subscription)
                 new_subscriptions.append(new_subscription)
-                model_dict = get_model_dict()
-                logger.debug(f"New subscription {model_dict(new_subscription)}")
+                logger.debug(f"New subscription {pydantic_to_dict(new_subscription)}")
             await EventNotifier.trigger_events(
                 self._on_subscribe_events, subscriber_id, topics
             )

--- a/fastapi_websocket_pubsub/event_notifier.py
+++ b/fastapi_websocket_pubsub/event_notifier.py
@@ -7,6 +7,7 @@ from fastapi_websocket_rpc.utils import gen_uid
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
 from .logger import get_logger
+from .util import get_model_dict
 
 logger = get_logger("EventNotifier")
 
@@ -129,7 +130,8 @@ class EventNotifier:
                 )
                 subscriptions.append(new_subscription)
                 new_subscriptions.append(new_subscription)
-                logger.debug(f"New subscription {new_subscription.dict()}")
+                model_dict = get_model_dict()
+                logger.debug(f"New subscription {model_dict(new_subscription)}")
             await EventNotifier.trigger_events(
                 self._on_subscribe_events, subscriber_id, topics
             )

--- a/fastapi_websocket_pubsub/rpc_event_methods.py
+++ b/fastapi_websocket_pubsub/rpc_event_methods.py
@@ -4,7 +4,7 @@ from fastapi_websocket_rpc import RpcMethodsBase
 
 from .event_notifier import EventNotifier, Subscription, TopicList
 from .logger import get_logger
-from .util import get_model_dict
+from .util import pydantic_to_dict
 
 
 class RpcEventServerMethods(RpcMethodsBase):
@@ -25,8 +25,9 @@ class RpcEventServerMethods(RpcMethodsBase):
             async def callback(subscription: Subscription, data):
                 # remove the actual function
                 sub = subscription.copy(exclude={"callback"})
-                model_dict = get_model_dict()
-                self.logger.info(f"Notifying other side: subscription={model_dict(subscription, exclude={'callback'})}, data={data}, channel_id={self.channel.id}")
+                self.logger.info(
+                    f"Notifying other side: subscription={pydantic_to_dict(subscription, exclude={'callback'})}, data={data}, channel_id={self.channel.id}"
+                )
                 await self.channel.other.notify(subscription=sub, data=data)
 
             if self._rpc_channel_get_remote_id:

--- a/fastapi_websocket_pubsub/rpc_event_methods.py
+++ b/fastapi_websocket_pubsub/rpc_event_methods.py
@@ -1,7 +1,10 @@
 import asyncio
+
 from fastapi_websocket_rpc import RpcMethodsBase
+
 from .event_notifier import EventNotifier, Subscription, TopicList
 from .logger import get_logger
+from .util import get_model_dict
 
 
 class RpcEventServerMethods(RpcMethodsBase):
@@ -22,7 +25,8 @@ class RpcEventServerMethods(RpcMethodsBase):
             async def callback(subscription: Subscription, data):
                 # remove the actual function
                 sub = subscription.copy(exclude={"callback"})
-                self.logger.info(f"Notifying other side: subscription={subscription.dict(exclude={'callback'})}, data={data}, channel_id={self.channel.id}")
+                model_dict = get_model_dict()
+                self.logger.info(f"Notifying other side: subscription={model_dict(subscription, exclude={'callback'})}, data={data}, channel_id={self.channel.id}")
                 await self.channel.other.notify(subscription=sub, data=data)
 
             if self._rpc_channel_get_remote_id:

--- a/fastapi_websocket_pubsub/util.py
+++ b/fastapi_websocket_pubsub/util.py
@@ -7,15 +7,15 @@ def is_pydantic_pre_v2():
     return version.parse(pydantic.VERSION) < version.parse("2.0.0")
 
 
-def get_model_serializer():
+def pydantic_serialize(model, **kwargs):
     if is_pydantic_pre_v2():
-        return lambda model, **kwargs: model.json(**kwargs)
+        return model.json(**kwargs)
     else:
-        return lambda model, **kwargs: model.model_dump_json(**kwargs)
+        return model.model_dump_json(**kwargs)
 
 
-def get_model_dict():
+def pydantic_to_dict(model, **kwargs):
     if is_pydantic_pre_v2():
-        return lambda model, **kwargs: model.dict(**kwargs)
+        return model.dict(**kwargs)
     else:
-        return lambda model, **kwargs: model.model_dump(**kwargs)
+        return model.model_dump(**kwargs)

--- a/fastapi_websocket_pubsub/util.py
+++ b/fastapi_websocket_pubsub/util.py
@@ -1,0 +1,21 @@
+import pydantic
+from packaging import version
+
+
+# Helper methods for supporting Pydantic v1 and v2
+def is_pydantic_pre_v2():
+    return version.parse(pydantic.VERSION) < version.parse("2.0.0")
+
+
+def get_model_serializer():
+    if is_pydantic_pre_v2():
+        return lambda model: model.json()
+    else:
+        return lambda model: model.model_dump_json()
+
+
+def get_model_parser():
+    if is_pydantic_pre_v2():
+        return lambda model, data: model.parse_obj(data)
+    else:
+        return lambda model, data: model.model_validate(data)

--- a/fastapi_websocket_pubsub/util.py
+++ b/fastapi_websocket_pubsub/util.py
@@ -14,8 +14,8 @@ def get_model_serializer():
         return lambda model: model.model_dump_json()
 
 
-def get_model_parser():
+def get_model_dict():
     if is_pydantic_pre_v2():
-        return lambda model, data: model.parse_obj(data)
+        return lambda model, **kwargs: model.dict(**kwargs)
     else:
-        return lambda model, data: model.model_validate(data)
+        return lambda model, **kwargs: model.model_dump(**kwargs)

--- a/fastapi_websocket_pubsub/util.py
+++ b/fastapi_websocket_pubsub/util.py
@@ -9,9 +9,9 @@ def is_pydantic_pre_v2():
 
 def get_model_serializer():
     if is_pydantic_pre_v2():
-        return lambda model: model.json()
+        return lambda model, **kwargs: model.json(**kwargs)
     else:
-        return lambda model: model.model_dump_json()
+        return lambda model, **kwargs: model.model_dump_json(**kwargs)
 
 
 def get_model_dict():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi-websocket-rpc>=0.1.25,<1
+packaging>=20.4
 permit-broadcaster[redis,postgres,kafka]>=0.2.5,<3
 pydantic>=1.9.1
 websockets>=10.3,<11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi-websocket-rpc>=0.1.24,<1
+fastapi-websocket-rpc>=0.1.25,<1
 permit-broadcaster[redis,postgres,kafka]>=0.2.5,<3
 pydantic>=1.9.1
 websockets>=10.3,<11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi-websocket-rpc>=0.1.24,<1
 permit-broadcaster[redis,postgres,kafka]>=0.2.5,<3
-pydantic>=1.9.1,<2
+pydantic>=1.9.1
 websockets>=10.3,<11

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="fastapi_websocket_pubsub",
-    version="0.3.8",
+    version="0.3.7",
     author="Or Weis",
     author_email="or@permit.io",
     description="A fast and durable PubSub channel over Websockets (using fastapi-websockets-rpc).",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="fastapi_websocket_pubsub",
-    version="0.3.7",
+    version="0.3.8",
     author="Or Weis",
     author_email="or@permit.io",
     description="A fast and durable PubSub channel over Websockets (using fastapi-websockets-rpc).",


### PR DESCRIPTION
pydantic is currently pinned to <2. This PR unpins and provides support for both v1 and v2, without deprecation warnings.

Edit: `fastapi_websocket_rpc`, which is in the requirements here, seems to also be pinned to <2. So, this PR is contingent on this one being released first: https://github.com/permitio/fastapi_websocket_rpc/pull/24. Version there is bumped to 0.1.25, so this PR is set to require `fastapi_websocket_rpc~=0.1.25`