### PR TITLE
Release 0.3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="fastapi_websocket_pubsub",
-    version="0.3.7",
+    version="0.3.8",
     author="Or Weis",
     author_email="or@permit.io",
     description="A fast and durable PubSub channel over Websockets (using fastapi-websockets-rpc).",


### PR DESCRIPTION
with a new `fastapi_websocket_rpc` version (0.1.27)