### PR TITLE
allow more recent websockets version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ fastapi-websocket-rpc>=0.1.25,<1
 packaging>=20.4
 permit-broadcaster[redis,postgres,kafka]>=0.2.5,<3
 pydantic>=1.9.1
-websockets>=10.3,<11
+websockets>=10.3


### PR DESCRIPTION
Updates the `websockets` dependency to allow more recent versions. Previously was pinned to <11.

Fixes #71
