### PR TITLE
Fix latest EventBroadcaster change to keep original behavior

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="fastapi_websocket_pubsub",
-    version="0.3.8",
+    version="0.3.9",
     author="Or Weis",
     author_email="or@permit.io",
     description="A fast and durable PubSub channel over Websockets (using fastapi-websockets-rpc).",


### PR DESCRIPTION
Moving the broadcaster channel `disconnect` call to `__aexit__` would not necessarily behave the same as calling `disconnect` upon exiting the reader task.