### PR TITLE
Log publisher and subscriber payloads at DEBUG level

### DIFF
--- a/fastapi_websocket_pubsub/rpc_event_methods.py
+++ b/fastapi_websocket_pubsub/rpc_event_methods.py
@@ -25,7 +25,7 @@ class RpcEventServerMethods(RpcMethodsBase):
             async def callback(subscription: Subscription, data):
                 # remove the actual function
                 sub = subscription.copy(exclude={"callback"})
-                self.logger.info(
+                self.logger.debug(
                     f"Notifying other side: subscription={pydantic_to_dict(subscription, exclude={'callback'})}, data={data}, channel_id={self.channel.id}"
                 )
                 await self.channel.other.notify(subscription=sub, data=data)
@@ -89,6 +89,6 @@ class RpcEventClientMethods(RpcMethodsBase):
         self.logger = get_logger('PubSubClient')
 
     async def notify(self, subscription=None, data=None):
-        self.logger.info("Received notification of event",
-                         {'subscription': subscription, 'data': data})
+        self.logger.debug("Received notification of event",
+                          {'subscription': subscription, 'data': data})
         await self.client.trigger_topic(topic=subscription["topic"], data=data)


### PR DESCRIPTION
Update logging of all payloads published by publishers and received by subscribers to use DEBUG instead of INFO logging level. With logging at INFO, users of this library with the default logging setup see log size grow at the rate of data pushed through the system with the previous behavior; with the behavior in this change, log size will grow much more slowly by default. The frequency of these logs in normal operation makes them more suited to a debug-specific level.