### PR TITLE
Make broadcaster dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ FastAPI + WebSockets + PubSub ==  ⚡💪 ❤️
         async def websocket_rpc_endpoint(websocket: WebSocket):
             await endpoint.main_loop(websocket)
         ```
-        see [examples/pubsub_broadcaster_server_example.py](examples/pubsub_broadcaster_server_example.py) for full usage example 
+        see [examples/pubsub_broadcaster_server_example.py](examples/pubsub_broadcaster_server_example.py) for full usage example
+        Note: Requires install with dependencies e.g. `pip install fastapi_websocket_pubsub[redis]`, `pip install fastapi_websocket_pubsub[postgres]`, `pip install fastapi_websocket_pubsub[kafka]` or `pip install fastapi_websocket_pubsub[all]` to get support for all three backends
 
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ wheel
 loguru
 uvicorn
 pytest-timeout
+permit-broadcaster[redis,postgres,kafka]>=0.2.5,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi-websocket-rpc>=0.1.25,<1
 packaging>=20.4
 pydantic>=1.9.1
-websockets>=10.3
+websockets>=14.0
 permit-broadcaster>=0.2.5,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi-websocket-rpc>=0.1.25,<1
 packaging>=20.4
 pydantic>=1.9.1
 websockets>=10.3
+permit-broadcaster>=0.2.5,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 fastapi-websocket-rpc>=0.1.25,<1
 packaging>=20.4
-permit-broadcaster[redis,postgres,kafka]>=0.2.5,<3
 pydantic>=1.9.1
 websockets>=10.3

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,10 @@ setup(
     ],
     python_requires=">=3.9",
     install_requires=get_requirements(),
+    extras_require = {
+        "redis": ["permit-broadcaster[redis]>=0.2.5,<3"],
+        "postgres": ["permit-broadcaster[postgres]>=0.2.5,<3"],
+        "kafka": ["permit-broadcaster[kafka]>=0.2.5,<3"],
+        "all": ["permit-broadcaster[redis,postgres,kafka]>=0.2.5,<3"],
+    }
 )

--- a/tests/broadcaster_test.py
+++ b/tests/broadcaster_test.py
@@ -22,6 +22,12 @@ sys.path.append(
 )
 from fastapi_websocket_pubsub import PubSubEndpoint, PubSubClient
 
+# Check if postgres backend is available
+asyncpg_backend_available = True
+try:
+    import asyncpg
+except ModuleNotFoundError:
+    asyncpg_backend_available = False
 
 logger = get_logger("Test")
 logger.remove()
@@ -129,6 +135,7 @@ def server(postgres):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not asyncpg_backend_available, reason="asyncpg dependency is not installed.")
 async def test_all_clients_get_a_topic_via_broadcast(server, repeats=1, interval=0):
     """
     if:
@@ -179,6 +186,7 @@ async def test_all_clients_get_a_topic_via_broadcast(server, repeats=1, interval
 
 @pytest.mark.postgres_idle_timeout(3000)
 @pytest.mark.asyncio
+@pytest.mark.skipif(not asyncpg_backend_available, reason="asyncpg dependency is not installed.")
 async def test_idle_pg_broadcaster_disconnect(server):
     """
     if:

--- a/tests/server_notifier_callback_test.py
+++ b/tests/server_notifier_callback_test.py
@@ -80,7 +80,7 @@ async def server_subscribe_to_topic(server, is_topic_permitted):
 
     # Create a client and subscribe to topics
     async with PubSubClient(
-        extra_headers={"headers": {"claims": {"permitted_topics": permitted_topics}}}
+        additional_headers={"headers": {"claims": {"permitted_topics": permitted_topics}}}
     ) as client:
 
         async def on_event(data, topic):
@@ -116,7 +116,7 @@ async def test_server_subscribe_to_permitted_topic(server):
 async def server_publish_to_topic(server, is_topic_permitted):
     # Create a client and subscribe to topics
     async with PubSubClient(
-        extra_headers={"headers": {"claims": {"permitted_topics": ["t1", "t2"]}}}
+        additional_headers={"headers": {"claims": {"permitted_topics": ["t1", "t2"]}}}
     ) as client:
         # start listentining
         client.start_client(uri)


### PR DESCRIPTION
An option is available for each backend as well as an "all" option which gets you everything.

* Install without options: `pip install fastapi_websocket_pubsub`
* Install with Redis broadcaster: `pip install fastapi_websocket_pubsub[redis]`
* Install with Postgres broadcaster: `pip install fastapi_websocket_pubsub[postgres]`
* Install with Kafka broadcaster: `pip install fastapi_websocket_pubsub[kafka]`
* Install with all options: `pip install fastapi_websocket_pubsub[all]`

This PR aims to close #57. I made this PR because it will enable me to install `fastapi_websocket_pubsub` on `python:3.13-alpine` Docker image without first installing `build-base` and `zlib-dev`.

Thanks a ton for this library. It's been quite useful and I appreciate that you maintain it and offer it to the community.

Br Eskild