### PR TITLE
Add unsubscribe method so client can unsubscribe from topics

### DIFF
--- a/fastapi_websocket_pubsub/pub_sub_client.py
+++ b/fastapi_websocket_pubsub/pub_sub_client.py
@@ -251,7 +251,7 @@ class PubSubClient:
 
     def subscribe(self, topic: Topic, callback: Coroutine):
         """
-        Subscribe for events (prior to starting the client)
+        Subscribe for events (before and after starting the client)
         @see fastapi_websocket_pubsub/rpc_event_methods.py :: RpcEventServerMethods.subscribe
 
         Args:
@@ -260,18 +260,25 @@ class PubSubClient:
                            'hello' or a complex path 'a/b/c/d' .
                            Note: You can use ALL_TOPICS (event_notifier.ALL_TOPICS) to subscribe to all topics
             callback (Coroutine): the function to call upon relevant event publishing
+
+        Returns:
+            Coroutine: awaitable task to subscribe to topic if connected.
         """
-        # TODO: add support for post connection subscriptions
-        if not self.is_ready():
-            self._topics.add(topic)
-            # init to empty list if no entry
-            callbacks = self._callbacks[topic] = self._callbacks.get(topic, [])
-            # add callback to callbacks list of the topic
-            callbacks.append(callback)
+        topic_is_new = topic not in self._topics
+        self._topics.add(topic)
+        # init to empty list if no entry
+        callbacks = self._callbacks[topic] = self._callbacks.get(topic, [])
+        # add callback to callbacks list of the topic
+        callbacks.append(callback)
+        if topic_is_new and self.is_ready():
+            return self._rpc_channel.other.subscribe(topics=[topic])
         else:
-            raise PubSubClientInvalidStateException(
-                "Client already connected and subscribed"
-            )
+            # If we can't return an RPC call future then we need
+            # to supply something else to not fail when the
+            # calling code awaits the result of this function.
+            future = asyncio.Future()
+            future.set_result(None)
+            return future
 
     async def publish(
         self, topics: TopicList, data=None, sync=True, notifier_id=None

--- a/fastapi_websocket_pubsub/pub_sub_server.py
+++ b/fastapi_websocket_pubsub/pub_sub_server.py
@@ -91,6 +91,10 @@ class PubSubEndpoint:
     ) -> List[Subscription]:
         return await self.notifier.subscribe(self._subscriber_id, topics, callback)
 
+    async def unsubscribe(
+        self, topics: Union[TopicList, ALL_TOPICS]) -> List[Subscription]:
+        return await self.notifier.unsubscribe(self._subscriber_id, topics)
+
     async def publish(self, topics: Union[TopicList, Topic], data=None):
         """
         Publish events to subscribres of given topics currently connected to the endpoint

--- a/fastapi_websocket_pubsub/rpc_event_methods.py
+++ b/fastapi_websocket_pubsub/rpc_event_methods.py
@@ -49,6 +49,19 @@ class RpcEventServerMethods(RpcMethodsBase):
                 "Failed to subscribe to RPC events notifier", topics)
             return False
 
+    async def unsubscribe(self, topics: TopicList = []) -> bool:
+        """
+        provided by the server so that the client can unsubscribe topics.
+        """
+        for topic in topics.copy():
+            if topic not in self.event_notifier._topics:
+                self.logger.warning(f"Cannot unsubscribe topic '{topic}' which is not subscribed.")
+                topics.remove(topic)
+        # We'll use the remote channel id as our subscriber id
+        sub_id = await self._get_channel_id_()
+        await self.event_notifier.unsubscribe(sub_id, topics)
+        return True
+
     async def publish(self, topics: TopicList = [], data=None, sync=True, notifier_id=None) -> bool:
         """
         Publish an event through the server to subscribers


### PR DESCRIPTION
Hi

My application is long running and the client will subscribe and unsubscribe to different topics during its lifetime. To this end this PR adds an `unsubscribe` method to go along with the `subscribe` method.
I figure that other users might also benefit from this addition, thus this PR.

The method returns `True` and logs a warning if a request is made to unsubscribe a topic which does not exist. This is in line with the behaviour of `fastapi_websocket_pubsub.event_notifier.EventNotifier.unsubscribe` which also returns `True` if a subscription is removed with a non-existent subscriber id.

I see that the current test cases are quite readable and appear like best-practice examples of how to use the library. I don't want to disturb that style with tedious tests. Do let me know if you think test cases are required.

Br Eskild